### PR TITLE
Add gset.

### DIFF
--- a/crdt/src/dotset.rs
+++ b/crdt/src/dotset.rs
@@ -9,7 +9,7 @@ pub trait ReplicaId: Copy + std::fmt::Debug + Ord + rkyv::Archive<Archived = Sel
 impl<T: Copy + std::fmt::Debug + Ord + rkyv::Archive<Archived = Self>> ReplicaId for T {}
 
 /// Dot is a version marker for a single replica.
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Archive, Deserialize, Serialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Archive, Deserialize, Serialize)]
 #[archive(as = "Dot<I>")]
 #[repr(C)]
 pub struct Dot<I: ReplicaId> {

--- a/crdt/src/lib.rs
+++ b/crdt/src/lib.rs
@@ -6,7 +6,7 @@ mod dotset;
 pub mod props;
 mod store;
 
-pub use crate::crdts::{EWFlag, MVReg, ORMap};
+pub use crate::crdts::{EWFlag, GSet, MVReg, ORMap};
 pub use crate::dotset::{Dot, DotSet, ReplicaId};
 pub use crate::store::{DotFun, DotMap, DotStore, Key};
 
@@ -15,6 +15,7 @@ pub use crate::store::{DotFun, DotMap, DotStore, Key};
 ///
 /// CausalContext = 𝑃(𝕀 ✕ ℕ)
 pub type CausalContext<I> = DotSet<I>;
+
 use bytecheck::CheckBytes;
 use rkyv::{Archive, Deserialize, Serialize};
 


### PR DESCRIPTION
so the tricky part about the gset is that it's not a causal crdt. This means it shouldn't be nested in an ORMap, but could probably be used in something like this:

```rust
struct Crdt { // a causal crdt
    data: Data, // a causal crdt
    policy: GSet,
}
```

the causal context is reset to prevent any elements from being removed. also I think we have to rethink the `Lattice` trait. It is only has to be a `Lattice` if a dot is reused. Not really sure what we can do about that. If we return an error, which is the proper thing to do we might permanently diverge. To prevent that we could remove the previous item in additon to the error.