### PR TITLE
Change fraction to a 7 bit encoding, and add some tests

### DIFF
--- a/crdt/src/fraction.rs
+++ b/crdt/src/fraction.rs
@@ -103,10 +103,10 @@ impl Fraction {
             digits.extend((0..n).map(|_| 0u8));
         }
         // add 1 to the lowest current fractional digit
-        for byte in digits.iter_mut().rev() {
+        for digit in digits.iter_mut().rev() {
             // add 1
-            *byte = (*byte + 1) & DIGIT_MASK_U8;
-            if *byte != 0 {
+            *digit = (*digit + 1) & DIGIT_MASK_U8;
+            if *digit != 0 {
                 break;
             }
         }
@@ -173,6 +173,7 @@ mod tests {
     }
 
     proptest! {
+
         #[test]
         fn mid(
             mut a in arb_fraction(),


### PR DESCRIPTION
This makes sure that fraction sorts properly in all cases. See ord test.

Implements https://github.com/cloudpeers/tlfs/issues/72 (Edit: as far as fraction is concerned)