### PR TITLE
Change storage api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3986,6 +3986,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.3",
  "hex",
+ "js-sys",
  "log-panics",
  "parking_lot",
  "proptest",
@@ -3995,7 +3996,11 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
+ "url",
  "vec-collections",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -9,11 +9,11 @@ use tlfs::Permission;
 pub struct Sdk(tlfs::Sdk);
 
 pub async fn create_persistent(path: &str, package: &[u8]) -> Result<Sdk> {
-    Ok(Sdk(tlfs::Sdk::persistent(
-        std::path::Path::new(path),
-        package,
-    )
-    .await?))
+    #[cfg(target_family = "wasm")]
+    let sdk = tlfs::Sdk::browser(path, package).await?;
+    #[cfg(not(target_family = "wasm"))]
+    let sdk = tlfs::Sdk::filesystem(std::path::Path::new(path), package).await?;
+    Ok(Sdk(sdk))
 }
 
 pub async fn create_memory(package: &[u8]) -> Result<Sdk> {

--- a/crdt/Cargo.toml
+++ b/crdt/Cargo.toml
@@ -21,15 +21,13 @@ rkyv = { version = "0.7.26", features = ["validation"] }
 smallvec = "1.7.0"
 tracing = { version = "0.1.29", default-features = false }
 vec-collections = { version = "0.4.3", features = ["radixtree", "rkyv", "rkyv_validated"] }
-wasm-bindgen-futures = { optional = true, version = "0.4.28" }
-js-sys = { optional = true, version = "0.3.55" }
-web-sys = { optional = true, version = "0.3.55", features = ['DomException', 'Cache', 'CacheStorage', 'CacheQueryOptions', 'Window', 'Request', 'Response'] }
-wasm-bindgen = { version = "0.2.78", optional = true }
-url = { version = "2.2.2", optional = true }
 
-[features]
-browser = ['web-sys', 'js-sys', 'wasm-bindgen', 'wasm-bindgen-futures', 'url']
-default = ["browser"]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-futures = { version = "0.4.28" }
+js-sys = { version = "0.3.55" }
+web-sys = { version = "0.3.55", features = ['DomException', 'Cache', 'CacheStorage', 'CacheQueryOptions', 'Window', 'Request', 'Response'] }
+wasm-bindgen = { version = "0.2.78" }
+url = { version = "2.2.2" }
 
 [dev-dependencies]
 async-std = { version = "1.10.0", features = ["attributes"] }

--- a/crdt/Cargo.toml
+++ b/crdt/Cargo.toml
@@ -21,6 +21,15 @@ rkyv = { version = "0.7.26", features = ["validation"] }
 smallvec = "1.7.0"
 tracing = { version = "0.1.29", default-features = false }
 vec-collections = { version = "0.4.3", features = ["radixtree", "rkyv", "rkyv_validated"] }
+wasm-bindgen-futures = { optional = true, version = "0.4.28" }
+js-sys = { optional = true, version = "0.3.55" }
+web-sys = { optional = true, version = "0.3.55", features = ['DomException', 'Cache', 'CacheStorage', 'CacheQueryOptions', 'Window', 'Request', 'Response'] }
+wasm-bindgen = { version = "0.2.78", optional = true }
+url = { version = "2.2.2", optional = true }
+
+[features]
+browser = ['web-sys', 'js-sys', 'wasm-bindgen', 'wasm-bindgen-futures', 'url']
+default = ["browser"]
 
 [dev-dependencies]
 async-std = { version = "1.10.0", features = ["attributes"] }

--- a/crdt/src/lib.rs
+++ b/crdt/src/lib.rs
@@ -161,3 +161,6 @@ pub use crate::registry::{Expanded, Hash, Package, Registry};
 pub use crate::schema::{ArchivedSchema, PrimitiveKind, Schema};
 pub use crate::subscriber::{Batch, Event, Iter, Subscriber};
 pub use crate::util::Ref;
+
+#[cfg(target_arch = "wasm32")]
+pub use crate::radixdb::browser::CacheFileStore;

--- a/crdt/src/lib.rs
+++ b/crdt/src/lib.rs
@@ -163,4 +163,4 @@ pub use crate::subscriber::{Batch, Event, Iter, Subscriber};
 pub use crate::util::Ref;
 
 #[cfg(target_arch = "wasm32")]
-pub use crate::radixdb::browser::CacheFileStore;
+pub use crate::radixdb::browser::BrowserCacheStorage;

--- a/crdt/src/radixdb.rs
+++ b/crdt/src/radixdb.rs
@@ -233,7 +233,6 @@ mod browser {
     use rkyv::AlignedVec;
     use std::{collections::BTreeMap, io, sync::Arc};
     use url::Url;
-    use wasm_bindgen::{prelude::Closure, JsValue};
     use wasm_bindgen_futures::JsFuture;
     use web_sys::{Cache, CacheQueryOptions, DomException, Request, Response};
 
@@ -298,7 +297,7 @@ mod browser {
                 .filter_map(|url| {
                     Url::parse(&url)
                         .ok()
-                        .and_then(|x| x.path().strip_prefix("/").map(|x| x.to_string()))
+                        .and_then(|x| x.path().strip_prefix('/').map(|x| x.to_string()))
                 })
                 .collect::<Vec<String>>();
             let mut data = BTreeMap::new();
@@ -323,7 +322,7 @@ mod browser {
                     data.entry(file.to_owned()).or_default()
                 };
                 vec.extend_from_slice(chunk);
-                fire_write(&self.cache, file, &vec).map_err(dom_to_io)?;
+                fire_write(&self.cache, file, vec).map_err(dom_to_io)?;
             }
             Ok(())
         }
@@ -333,7 +332,7 @@ mod browser {
             let mut entry = AlignedVec::new();
             entry.extend_from_slice(content);
             data.insert(file.to_owned(), entry);
-            fire_write(&self.cache, file, &content).map_err(dom_to_io)?;
+            fire_write(&self.cache, file, content).map_err(dom_to_io)?;
             Ok(())
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,11 +48,15 @@ impl Sdk {
 
     /// Create a new in-memory [`Sdk`] instance.
     pub async fn memory(package: &[u8]) -> Result<Self> {
-        Self::new(
-            std::sync::Arc::new(tlfs_crdt::MemStorage::default()),
-            package,
-        )
-        .await
+        #[cfg(target_arch = "wasm32")]
+        let storage = std::sync::Arc::new(
+            tlfs_crdt::CacheFileStore::new("tlfs".to_owned())
+                .await
+                .unwrap(),
+        );
+        #[cfg(not(target_arch = "wasm32"))]
+        let storage = std::sync::Arc::new(tlfs_crdt::MemStorage::default());
+        Self::new(storage, package).await
     }
 
     #[allow(clippy::if_same_then_else)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@ impl Sdk {
 
     /// Create a new in-memory [`Sdk`] instance.
     pub async fn memory(package: &[u8]) -> Result<Self> {
+        // package will be invalid after the first suspend, so we need to save it to the heap
+        let package = package.to_vec();
         #[cfg(target_arch = "wasm32")]
         let storage = std::sync::Arc::new(
             tlfs_crdt::CacheFileStore::new("tlfs".to_owned())
@@ -56,7 +58,7 @@ impl Sdk {
         );
         #[cfg(not(target_arch = "wasm32"))]
         let storage = std::sync::Arc::new(tlfs_crdt::MemStorage::default());
-        Self::new(storage, package).await
+        Self::new(storage, &package).await
     }
 
     #[allow(clippy::if_same_then_else)]


### PR DESCRIPTION
Remove mv, add set, leave the temp file stuff as an implementation detail of the file storage.

Add `BrowserCacheStorage`, which is basically like a memory based storage that gets initialized from a browser cache directory on startup, and *completely* writes each file to the browser cache on each update.

The BrowserCacheStorage is available whenever we have a wasm target family, but it will obviously only work when we are actually in a browser and have web_sys available.