### PR TITLE
Minor rkyv version update...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3597,9 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.28"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631f7d2a2854abb66724f492ce5256e79685a673dc210ac022194cedd5c914d3"
+checksum = "439655b8d657bcb28264da8e5380d55549e34ffc4149bea9e3521890a122a7bd"
 dependencies = [
  "bytecheck",
  "hashbrown",
@@ -3611,9 +3611,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.28"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c067e650861a749720952aed722fb344449bc95de33e6456d426f5c7d44f71c0"
+checksum = "cded413ad606a80291ca84bedba137093807cf4f5b36be8c60f57a7e790d48f6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crdt/src/doc.rs
+++ b/crdt/src/doc.rs
@@ -66,7 +66,7 @@ impl Docs {
     pub fn docs(&self) -> impl Iterator<Item = Result<DocId>> + '_ {
         self.0.iter().filter_map(|(k, _)| {
             if k[32] == 1 {
-                Some(Ok(DocId::new((&k[..32]).try_into().unwrap())))
+                Some(Ok(DocId::new(k[..32].try_into().unwrap())))
             } else {
                 None
             }
@@ -76,7 +76,7 @@ impl Docs {
     pub fn keys(&self) -> impl Iterator<Item = Result<PeerId>> + '_ {
         self.0.iter().filter_map(|(k, _)| {
             if k[32] == 2 {
-                Some(Ok(PeerId::new((&k[..32]).try_into().unwrap())))
+                Some(Ok(PeerId::new(k[..32].try_into().unwrap())))
             } else {
                 None
             }

--- a/crdt/src/radixdb.rs
+++ b/crdt/src/radixdb.rs
@@ -87,7 +87,7 @@ impl Fallible for SharedSerializeMap2 {
 }
 
 impl SharedSerializeRegistry for SharedSerializeMap2 {
-    fn get_shared_ptr(&mut self, value: *const u8) -> Option<usize> {
+    fn get_shared_ptr(&self, value: *const u8) -> Option<usize> {
         self.shared_resolvers.get(&value).copied()
     }
 


### PR DESCRIPTION
and fix resulting compile error.

I only updated rkyv. Tried updating everything, but that leads to an unrelated error:

```
   Compiling libp2p-webrtc v0.2.1 (https://github.com/wngr/libp2p-webrtc?branch=tlfs#e809482e)
error[E0046]: not all trait items implemented, missing: `dial_as_listener`
  --> /home/rklaehn/.cargo/git/checkouts/libp2p-webrtc-7146c75545a02a20/e809482/libp2p-webrtc/src/lib.rs:89:1
   |
89 | impl Transport for WebRtcTransport {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `dial_as_listener` in implementation
   |
   = help: implement the missing item: `fn dial_as_listener<Self>(self, _: Multiaddr) -> Result<<Self as libp2p::Transport>::Dial, TransportError<<Self as libp2p::Transport>::Error>> { todo!() }`

For more information about this error, try `rustc --explain E0046`.
error: could not compile `libp2p-webrtc` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed
```